### PR TITLE
Return empty LinkedHashMap instead of `Collections.emptyMap()` in PathVariableMapMethodArgumentResolver

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/PathVariableMapMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/PathVariableMapMethodArgumentResolver.java
@@ -17,7 +17,6 @@
 package org.springframework.web.servlet.mvc.method.annotation;
 
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.springframework.core.MethodParameter;
@@ -63,7 +62,7 @@ public class PathVariableMapMethodArgumentResolver implements HandlerMethodArgum
 						HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE, RequestAttributes.SCOPE_REQUEST);
 
 		if (!CollectionUtils.isEmpty(uriTemplateVars)) {
-			return new LinkedHashMap<>(uriTemplateVars);
+			return Collections.unmodifiableMap(uriTemplateVars);
 		}
 		else {
 			return Collections.emptyMap();


### PR DESCRIPTION
Return empty LinkedHashMap instead of `Collections.emptyMap()` in PathVariableMapMethodArgumentResolver